### PR TITLE
Splitting the pipeline targets into 3 different makefiles by phase.

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,0 +1,25 @@
+source("1_fetch/src/get_nwis_data.R")
+
+p1_targets_list <- list(
+  tar_target(p1_site_data_01427207, download_nwis_site_data('01427207')),
+  tar_target(p1_site_data_01432160, download_nwis_site_data('01432160')),
+  tar_target(p1_site_data_01436690, download_nwis_site_data('01436690')),
+  tar_target(p1_site_data_01466500, download_nwis_site_data('01466500')),
+  
+  tar_target(p1_site_data_csv,
+             {
+               out_file <- "1_fetch/out/site_data.csv"
+               list(p1_site_data_01427207, p1_site_data_01432160, 
+                    p1_site_data_01436690, p1_site_data_01466500) %>% 
+                 bind_rows()%>%
+                 write_csv(out_file)
+               return(out_file)
+             },
+             format = "file"
+  ),
+  
+  tar_target(
+    p1_site_info,
+    nwis_site_info(filein = p1_site_data_csv)
+  )
+)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -15,7 +15,8 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01436690",
   return(data_out)
 }
 
-nwis_site_info <- function(site_data){
+nwis_site_info <- function(filein){
+  site_data<- read_csv(filein)
   site_num <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_num)
   return(site_info)

--- a/2_process.R
+++ b/2_process.R
@@ -1,0 +1,16 @@
+source("2_process/src/process_and_style.R")
+
+p2_targets_list <- list(
+  tar_target(
+    p2_nwis_data_clean_csv, 
+    process_data(filein = p1_site_data_csv, 
+                 fileout = "2_process/out/nwis_data_clean.csv"),
+    format = "file"
+  ),
+  tar_target(
+    p2_cleaned_data_csv,
+    annotate_and_style_data(filein = p2_nwis_data_clean_csv, site_info = p1_site_info,
+                            fileout = "2_process/out/cleaned_data.csv"),
+    format = "file"
+  )
+)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,4 +1,5 @@
-process_data <- function(site_data, fileout){
+process_data <- function(filein, fileout){
+  site_data<- read_csv(filein)
   nwis_data_clean <- rename(site_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)
   write_csv(nwis_data_clean, fileout)
@@ -6,8 +7,8 @@ process_data <- function(site_data, fileout){
 }
 
 annotate_and_style_data <- function(filein, site_info, fileout){
-  site_data<- read_csv(filein)
-  annotated_data <- left_join(site_data, site_info, by = "site_no") %>% 
+  nwis_data_clean<- read_csv(filein)
+  annotated_data <- left_join(nwis_data_clean, site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)%>%
     mutate(station_name = as.factor(station_name))
     write_csv(annotated_data, fileout)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,0 +1,9 @@
+source("3_visualize/src/plot_timeseries.R")
+
+p3_targets_list <- list(
+  tar_target(
+    p3_figure_1_png,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", filein = p2_cleaned_data_csv),
+    format = "file"
+  )
+)

--- a/_targets.R
+++ b/_targets.R
@@ -1,53 +1,14 @@
 library(targets)
-source("1_fetch/src/get_nwis_data.R")
-source("2_process/src/process_and_style.R")
-source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+# Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+tar_option_set(packages = c("tidyverse", "dataRetrieval")) 
 
-p1_targets_list <- list(
-  tar_target(site_data_01427207, download_nwis_site_data('01427207')),
-  tar_target(site_data_01432160, download_nwis_site_data('01432160')),
-  tar_target(site_data_01436690, download_nwis_site_data('01436690')),
-  tar_target(site_data_01466500, download_nwis_site_data('01466500')),
-  
-  tar_target(site_data,
-             {
-               site_data<-list(site_data_01427207, site_data_01432160, 
-                    site_data_01436690, site_data_01466500) %>% 
-                 bind_rows() 
-               return(site_data)
-             }
-  ),
-  
-  tar_target(
-    site_info,
-    nwis_site_info(site_data = site_data)
-  )
-)
 
-p2_targets_list <- list(
-  tar_target(
-    nwis_data_clean_csv, 
-    process_data(site_data = site_data, 
-                 fileout = "2_process/out/nwis_data_clean.csv"),
-    format = "file"
-  ),
-tar_target(
-  cleaned_data_csv,
-  annotate_and_style_data(filein = nwis_data_clean_csv, site_info = site_info,
-                          fileout = "2_process/out/cleaned_data.csv"),
-  format = "file"
-)
-)
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", filein = cleaned_data_csv),
-    format = "file"
-  )
-)
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
+
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
Split the pipeline targets into three separate makefiles: 1_fetch, 2_process and 3_visualize. I also renamed each target using the appropriate prefix (p1, p2 or p3).

